### PR TITLE
Migrate to CLI-based tool, multithread download, better error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+tmp/
+*.pdf
+.idea/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+links.txt
 tmp/
 *.pdf
 .idea/

--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ Hathi Trust Digital Library is a good site to find old publications digitized fr
   - https://babel.hathitrust.org/cgi/pt?id={bookID}
   - https://hdl.handle.net/XXXX/{bookID}
 - Book splicing, allowing to download only a part of the book.
+- Bulk download of multiple books.
 - Attempts to avoid Error 429 (Too Many Requests) from Hathi Trust.
   - If the error occurs, the thread will sleep for 5 seconds and try again.
   - Works in most cases, but not always.
 - Downloads are attempted 3 times before giving up.
-  - Users are notified of the failure, and have the option to manually download the missing pages for merge at the end.
+  - Users are notified of the failure, and have the option to redownload the missing pages for merge at the end.
+  - Retry attempt count is configurable via --retries option.
 
 # Requirements
 * [BeautifulSoup](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#installing-beautiful-soup) (bs4)
@@ -26,17 +28,20 @@ Hathi Trust Digital Library is a good site to find old publications digitized fr
 # Usage
 
 ```
-usage: hathitrustPDF.py [-h] [-t THREAD_COUNT] [-b BEGIN] [-e END] [-k] [-o OUTPUT_PATH] [-v] [-V] link
+usage: hathitrustPDF.py [-h] [-l LINK] [-i INPUT_FILE] [-t THREAD_COUNT] [-r RETRIES] [-b BEGIN] [-e END] [-k]
+                        [-o OUTPUT_PATH] [-v] [-V]
 
 PDF Downloader and Merger
 
-positional arguments:
-  link                  HathiTrust book link
-
 options:
   -h, --help            show this help message and exit
+  -l LINK, --link LINK  HathiTrust book link
+  -i INPUT_FILE, --input-file INPUT_FILE
+                        File with list of links formatted as link,output_path
   -t THREAD_COUNT, --thread-count THREAD_COUNT
                         Number of download threads
+  -r RETRIES, --retries RETRIES
+                        Number of retries for failed downloads
   -b BEGIN, --begin BEGIN
                         First page to download
   -e END, --end END     Last page to download

--- a/README.md
+++ b/README.md
@@ -4,35 +4,45 @@ Download an entire book (or publication) in PDF from Hathi Trust Digital Library
 # Motivation
 Hathi Trust Digital Library is a good site to find old publications digitized from different university libraries. However, it limits the download of full PDF files to only partner universities, which are mostly american. In this sense, this code attempts to democratize knowledge and permits to download complete public domain works in PDF from Hathi Trust website.
 
+# Features
+- Multi-threaded download of PDF pages and merge in a single file.
+- Smart download of pages, skipping already downloaded pages.
+- Supports the two most common link formats:
+  - https://babel.hathitrust.org/cgi/pt?id={bookID}
+  - https://hdl.handle.net/XXXX/{bookID}
+- Book splicing, allowing to download only a part of the book.
+- Attempts to avoid Error 429 (Too Many Requests) from Hathi Trust.
+  - If the error occurs, the thread will sleep for 5 seconds and try again.
+  - Works in most cases, but not always.
+- Downloads are attempted 3 times before giving up.
+  - Users are notified of the failure, and have the option to manually download the missing pages for merge at the end.
+
 # Requirements
 * [BeautifulSoup](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#installing-beautiful-soup) (bs4)
 * [Requests](https://realpython.com/python-requests/)
 * [PyPDF2](https://pythonhosted.org/PyPDF2/)
 * [Progressbar](https://pypi.org/project/progressbar/)
 
-# How to use it
-Copy Hathi Trust book URL and paste into "link" variable on code line:
-```python
-...
-link = "https://babel.hathitrust.org/cgi/pt?id=mdp.39015023320164"
-r  = requests.get(link)
-...
+# Usage
+
 ```
-OBS: Keep the same pattern presented (**numbers at the end**)! 
+usage: hathitrustPDF.py [-h] [-t THREAD_COUNT] [-b BEGIN] [-e END] [-k] [-o OUTPUT_PATH] [-v] [-V] link
 
-After that, all pages will be downloaded as PDF files and merged in a single file named ```BOOKNAME_output.pdf``` in the corresponding folder. The individual pages are not deleted after the end of the process! 
+PDF Downloader and Merger
 
-# Slice pages
-The code also allows you to remove only a range of pages. For that purpose, just edit the start and end page on code line:
-```python
-...
-# Download pdf file
-begin_page=1
-last_page=pages_book+1
+positional arguments:
+  link                  HathiTrust book link
 
-for actual_page in range(begin_page, last_page):
-...
+options:
+  -h, --help            show this help message and exit
+  -t THREAD_COUNT, --thread-count THREAD_COUNT
+                        Number of download threads
+  -b BEGIN, --begin BEGIN
+                        First page to download
+  -e END, --end END     Last page to download
+  -k, --keep            Keep downloaded pages
+  -o OUTPUT_PATH, --output-path OUTPUT_PATH
+                        Output file path
+  -v, --verbose         Enable verbose mode
+  -V, --version         show program's version number and exit
 ```
-
-# Screenshot
-![captura-hait](https://user-images.githubusercontent.com/56649205/72007547-abc73680-3230-11ea-9e74-4e6e495c90d2.PNG)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# This is currently **broken**. Hathi Trust has changed its page structure and now uses blob urls to store the images, and I don't have the time to rewrite this to accommodate for that. It's likely still possible, using selenium to request the page and pull it from there, but I'm not familiar enough with selenium or blob urls as a whole to do it. If someone else wants to make a pull request, feel free.
+
 # Hathi Trust Digital Library - Complete PDF Download
 Download an entire book (or publication) in PDF from Hathi Trust Digital Library without "partner login" requirement.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# This is currently **broken**. Hathi Trust has changed its page structure and now uses blob urls to store the images, and I don't have the time to rewrite this to accommodate for that. It's likely still possible, using selenium to request the page and pull it from there, but I'm not familiar enough with selenium or blob urls as a whole to do it. If someone else wants to make a pull request, feel free.
-
 # Hathi Trust Digital Library - Complete PDF Download
 Download an entire book (or publication) in PDF from Hathi Trust Digital Library without "partner login" requirement.
 

--- a/hathitrustPDF.py
+++ b/hathitrustPDF.py
@@ -154,7 +154,7 @@ def main():
 def download_link(args, link, output):
     start_time = time.time()
     if "babel.hathitrust.org" in link:
-        id_book = re.findall(r'id=(\w*\.\d*)|$', link)[0]
+        id_book = re.findall(r'id=(\w*\.\w*)|$', link)[0]
     elif "hdl.handle.net" in link:
         link.rstrip('/')
         id_book = re.findall(r'.+/(.+)', link)[0]

--- a/hathitrustPDF.py
+++ b/hathitrustPDF.py
@@ -1,74 +1,250 @@
-from bs4 import BeautifulSoup
-import requests
-import re
+#!/usr/bin/env python3
+import argparse
 import os
+import re
+import threading
+import time
 from pathlib import Path
-from PyPDF2 import PdfFileMerger
+
 import progressbar
+import requests
+from PyPDF2 import PdfMerger
+from bs4 import BeautifulSoup
 
 
-def PDFDownload(output_line):
-    PDF_download = requests.get(output_line, stream=True, timeout=300)
-    with open(path_folder + 'page' + str(actual_page) + '.pdf', 'wb') as f:
-        f.write(PDF_download.content)
+class Downloader:
+    def __init__(self, max_threads, to_download, bar_, path, verbose):
+        self.max_threads = max_threads
+        self.download_threads = []
+        self.finished_threads = []
+        self.to_download = to_download
+        self.bar = bar_
+        self.lock = threading.Lock()
+        self.path = path
+        self.verbose = verbose
+
+    def download(self):
+        def download_finished(thread_: DownloadThread):  # callback function
+            self.finished_threads.append(thread_)
+            self.bar.update(1)
+            with self.lock:
+                if len(self.to_download) > 0:
+                    # create new thread with new ID, link, and callback
+                    new_thread = DownloadThread(link_=self.to_download.pop(0), downloader_=self,
+                                                callback=download_finished)
+                    self.download_threads.append(new_thread)
+                    new_thread.start()
+
+                else:
+                    if len(self.download_threads) == len(self.finished_threads):
+                        if self.verbose:
+                            print("All downloads finished\n")
+
+        # Start initial set of threads
+        for _ in range(min(self.max_threads, len(self.to_download))):
+            thread = DownloadThread(link_=self.to_download.pop(0), downloader_=self,
+                                    callback=download_finished)
+            self.download_threads.append(thread)
+            thread.start()
+
+        # Wait for all download threads to finish
+        for thread in self.download_threads:
+            thread.join()
+
+    def download_file(self, link_):
+        retry_count = 0
+        page_number = re.search(r"seq=(\d+)", link_)
+        if page_number is not None:
+            page_number = page_number.group(1)
+        else:
+            page_number = ""
+        if self.verbose:
+            print(f"Downloading page {page_number}")
+        # check if file exists
+        if os.path.exists(os.path.join(self.path, 'page' + page_number + '.pdf')):
+            if self.verbose:
+                print(f"File page{page_number}.pdf already exists. Skipping...")
+            return
+        pdf_download = requests.get(link_, stream=True, timeout=300)
+        if pdf_download.status_code != 200:
+
+            while retry_count <= 3:
+                if pdf_download.status_code == 200:
+                    break
+                retry_count += 1
+                if self.verbose:
+                    print(f"Error downloading {link_}: Status code {pdf_download.status_code}. Retrying...{retry_count}/3")
+                if pdf_download.status_code == 429:
+                    if self.verbose:
+                        print("Too many requests. Waiting 5 seconds...")
+                    time.sleep(5)
+                pdf_download = requests.get(link_, stream=True, timeout=300)
+            if pdf_download.status_code != 200:
+                if self.verbose:
+                    print(f"Error downloading {link_} with status code {pdf_download.status_code}. Skipping...")
+                return
+
+        path = os.path.join(self.path, 'page' + page_number + '.pdf')
+        try:
+            with open(path, 'wb') as f:
+                f.write(pdf_download.content)
+        except Exception as e_:
+            if self.verbose:
+                print("Error writing file " + path)
+                print(e_)
+            return
+        if self.verbose:
+            print(f"Finished downloading page {page_number}")
 
 
-# Get hathitrust book link
-link = "https://babel.hathitrust.org/cgi/pt?id=txu.059173023561817"
-id_book = re.findall('id=(\w*\.\d*)|$', link)[0]
-r = requests.get(link)
-soup = BeautifulSoup(r.text, "html.parser")
+class DownloadThread(threading.Thread):
+    def __init__(self, link_, downloader_, callback):
+        threading.Thread.__init__(self)
+        self.link = link_  # link to download
+        self.downloader = downloader_  # Downloader object
+        self.callback = callback  # callback function to call when download is finished
 
-# Number of the book pages and name
-pages_book = int(soup.find("section", {'class': 'd--reader--viewer'})['data-total-seq'])
-name_book = soup.find('meta', {'property': 'og:title'})['content']
-
-# Limit book title
-if len(name_book) > 55:
-    name_book = name_book[:40]
-
-# Remove invalid characters
-remove_character = "[],/\\:.;\"'?!*"
-name_book = name_book.translate(
-            str.maketrans(remove_character, len(remove_character)*" ")).strip()
-
-# Create a new folder
-local = os.getcwd()
-Path(local + "/" + name_book).mkdir(parents=True, exist_ok=True)
-path_folder = local + "/" + name_book + "/"
-
-# Download pdf file
-begin_page = 1
-last_page = pages_book + 1
-
-# ProgressBar
-bar = progressbar.ProgressBar(maxval=last_page,
-                              widgets=[progressbar.Bar('=', '[', ']'), ' ',
-                                       progressbar.Percentage()])
-bar.start()
-
-for actual_page in range(begin_page, last_page):
-    output_line = f'https://babel.hathitrust.org/cgi/imgsrv/download/pdf?id={id_book};orient=0;size=100;seq={actual_page};attachment=0'
-    PDFDownload(output_line)
-
-    while os.path.getsize(path_folder + 'page' + str(actual_page) + '.pdf') < 6000:
-        PDFDownload(output_line)
-
-    bar.update(actual_page + 1)
+    def run(self):
+        self.downloader.download_file(self.link)
+        self.callback(self)
 
 
-# Merge all pdf files
-ordered_files = sorted(os.listdir(path_folder),
-                       key=lambda x: (int(re.sub('\D', '', x)), x))
+def check_files_missing(begin, end, path_folder, pdf_list):
+    missing_pages = []
+    for page in range(begin, end):
+        if os.path.join(path_folder, f"page{page}.pdf") not in pdf_list:
+            missing_pages.append(page)
+    for file in os.listdir(path_folder):
+        if os.path.getsize(os.path.join(path_folder, file)) == 0:
+            missing_pages.append(int(file[4:-4]))
 
-pdf_list = [path_folder + a for a in ordered_files if a.endswith(".pdf")]
-merger = PdfFileMerger()
+    return missing_pages
 
-for pdf in pdf_list:
-    merger.append(open(pdf, 'rb'))
 
-with open(path_folder + name_book + "_output.pdf", "wb") as fout:
-    merger.write(fout)
+def main():
+    parser = argparse.ArgumentParser(description='PDF Downloader and Merger')
+    parser.add_argument('link', help='HathiTrust book link')
+    parser.add_argument('-t', '--thread-count', type=int, default=5, help='Number of download threads')
+    parser.add_argument('-b', '--begin', type=int, default=1, help='First page to download')
+    parser.add_argument('-e', '--end', type=int, default=0, help='Last page to download')
+    parser.add_argument('-k', '--keep', action='store_true', help='Keep downloaded pages')
+    parser.add_argument('-o', '--output-path', default=None, help='Output file path')
+    parser.add_argument('-v', '--verbose', action='store_true', help='Enable verbose mode')
+    parser.add_argument('-V', '--version', action='version', version='%(prog)s 1.0')
+
+    args = parser.parse_args()
+
+    link = args.link
+
+    if "babel.hathitrust.org" in link:
+        id_book = re.findall(r'id=(\w*\.\d*)|$', link)[0]
+    elif "hdl.handle.net" in link:
+        link.rstrip('/')
+        id_book = re.findall(r'.+/(.+)', link)[0]
+    else:
+        print("Unknown link format. Please use a link from babel.hathitrust.org or hdl.handle.net")
+        exit(1)
+    r = requests.get(link)
+    soup = BeautifulSoup(r.text, "html.parser")
+
+    # Number of the book pages and name
+    pages_book = int(soup.find("section", {'class': 'd--reader--viewer'})['data-total-seq'])
+    name_book = soup.find('meta', {'property': 'og:title'})['content']
+
+    # Limit book title
+    if len(name_book) > 55:
+        name_book = name_book[:40]
+
+    # Remove invalid characters
+    remove_character = "[],/\\:.;\"'?!*"
+    name_book = name_book.translate(
+                str.maketrans(remove_character, len(remove_character)*" ")).strip()
+    if args.output_path is None:
+        args.output_path = name_book + ".pdf"
+    # Create a new folder
+    local = os.getcwd()
+    path_folder = os.path.join(local, "tmp")
+    Path(path_folder).mkdir(parents=True, exist_ok=True)
+
+    # Download pdf file
+    begin_page = args.begin
+    last_page = pages_book + 1 if (args.end == 0 or args.end > pages_book + 1) else args.end + 1
+
+    # ProgressBar
+    bar = progressbar.ProgressBar(maxval=last_page,
+                                  widgets=[progressbar.Bar('=', '[', ']'), ' ',
+                                           progressbar.Percentage()])
+    bar.start()
+    base_link = 'https://babel.hathitrust.org/cgi/imgsrv/download/pdf?id={};orient=0;size=100;seq={};attachment=0'
+    links = [base_link.format(id_book, actual_page) for actual_page in range(begin_page, last_page)]
+
+    downloader = Downloader(max_threads=args.thread_count, to_download=links, bar_=bar,
+                            path=path_folder, verbose=args.verbose)
+    downloader.download()
+
+    # Sort by page number, trims "page" and ".pdf"
+    ordered_files = sorted(os.listdir(path_folder), key=lambda x: int(x[4:-4]))
+
+    # Merge PDF files
+    pdf_list = [os.path.join(path_folder, a) for a in ordered_files if a.endswith(".pdf")]
+    # print(pdf_list)
+    missing_pages = check_files_missing(begin_page, last_page, path_folder, pdf_list)
+
+    # Check if there are missing pages
+    while len(missing_pages) > 0:
+        for page in missing_pages:
+            print(f"Missing/corrupted page {page}. Download it manually at {base_link.format(id_book, page)}, and "
+                  f"save it to {os.path.join(path_folder, f'page{page}.pdf')}.\n")
+        print("You have missing pages. Press enter to continue, R to recheck, or CTRL+C to exit.")
+        try:
+            # Wait for user input
+            while True:
+                key = input()
+                if key.lower() == "r":
+                    # Recheck missing pages
+                    missing_pages = check_files_missing(begin_page, last_page, path_folder, pdf_list)
+                    break
+                elif key == "":
+                    # force continue, even with missing pages
+                    missing_pages = []
+                    break
+        except KeyboardInterrupt:
+            print("Exiting...")
+            exit(1)
+
+    merger = PdfMerger()
+
+    for pdf in pdf_list:
+        with open(pdf, 'rb') as file:
+            merger.append(file)
+
+    try:
+        with open(args.output_path, "wb") as fout:
+            merger.write(fout)
+    except Exception as e:
+        print("Error writing merged file " + args.output_path)
+        print(e)
+
+    # Cleanup
+    if not args.keep:
+        for i in pdf_list:
+            try:
+                os.remove(os.path.join(path_folder, i))
+            except Exception as e:
+                print("Error removing file " + i)
+                print(e)
+        try:
+            os.rmdir(path_folder)
+        except Exception as e:
+            print("Error removing folder " + path_folder)
+            print(e)
+
+    bar.finish()
     merger.close()
+    exit(0)
 
-bar.finish()
+
+if __name__ == '__main__':
+    main()
+
+

--- a/hathitrustPDF.py
+++ b/hathitrustPDF.py
@@ -202,6 +202,7 @@ def main():
                 key = input()
                 if key.lower() == "r":
                     # Recheck missing pages
+                    ordered_files = sorted(os.listdir(path_folder), key=lambda x: int(x[4:-4]))
                     pdf_list = [os.path.join(path_folder, a) for a in ordered_files if a.endswith(".pdf")]
                     missing_pages = check_files_missing(begin_page, last_page, path_folder, pdf_list)
                     break

--- a/hathitrustPDF.py
+++ b/hathitrustPDF.py
@@ -152,6 +152,7 @@ def main():
 
 
 def download_link(args, link, output):
+    start_time = time.time()
     if "babel.hathitrust.org" in link:
         id_book = re.findall(r'id=(\w*\.\d*)|$', link)[0]
     elif "hdl.handle.net" in link:
@@ -267,6 +268,7 @@ def download_link(args, link, output):
 
     bar.finish()
     merger.close()
+    print(f"Finished downloading {output}. Took {time.time() - start_time} seconds.")
 
 
 if __name__ == '__main__':

--- a/hathitrustPDF.py
+++ b/hathitrustPDF.py
@@ -68,7 +68,7 @@ class Downloader:
         pdf_download = requests.get(link_, stream=True, timeout=300)
         if pdf_download.status_code != 200:
 
-            while retry_count <= 3:
+            while retry_count < 3:
                 if pdf_download.status_code == 200:
                     break
                 retry_count += 1

--- a/hathitrustPDF.py
+++ b/hathitrustPDF.py
@@ -202,6 +202,7 @@ def main():
                 key = input()
                 if key.lower() == "r":
                     # Recheck missing pages
+                    pdf_list = [os.path.join(path_folder, a) for a in ordered_files if a.endswith(".pdf")]
                     missing_pages = check_files_missing(begin_page, last_page, path_folder, pdf_list)
                     break
                 elif key == "":

--- a/hathitrustPDF.py
+++ b/hathitrustPDF.py
@@ -195,7 +195,7 @@ def main():
         for page in missing_pages:
             print(f"Missing/corrupted page {page}. Download it manually at {base_link.format(id_book, page)}, and "
                   f"save it to {os.path.join(path_folder, f'page{page}.pdf')}.\n")
-        print("You have missing pages. Press enter to continue, R to recheck, or CTRL+C to exit.")
+        print("You have missing pages. Press enter to continue, R to recheck, D to redownload, or CTRL+C to exit.")
         try:
             # Wait for user input
             while True:
@@ -206,6 +206,11 @@ def main():
                     pdf_list = [os.path.join(path_folder, a) for a in ordered_files if a.endswith(".pdf")]
                     missing_pages = check_files_missing(begin_page, last_page, path_folder, pdf_list)
                     break
+                elif key =="d":
+                    # Try to download missing pages
+                    for i in missing_pages:
+                        downloader.download_file(base_link.format(id_book, i))
+
                 elif key == "":
                     # force continue, even with missing pages
                     missing_pages = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+beautifulsoup4
+progressbar
+PyPDF2
+requests


### PR DESCRIPTION
The tool is now command-line based, instead of modifying the link variable directly.
- You can use --link [link] or --input-file [path] to download books

Configurable output path
- You can use --output-path in conjunction with --link, or --input-file formatted with `link,output_path`

Removes temporary pages by default
- Can be kept by passing --keep

Book splicing can be done with flags instead of modifying variables directly
- Configured with flags --begin, --end

Uses `os.path.join` instead of hardcoded UNIX-based paths

The main download is multithreaded to download multiple files at once, useful for larger books
- Defaults to 5 threads, configurable with --thread-count

Retries failed downloads several times and will sleep for a few seconds in case of 429 Too many requests
- Defaults to 3 retries, configurable with --retries

In the event of missing pages, you get a prompt at the end where you can force continue, download manually, or attempt to redownload automatically (single-threaded)